### PR TITLE
Update gtk deps, remove obsolete dox feature and bump version no

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,8 +26,10 @@ jobs:
         with:
             toolchain: nightly
             components: rustfmt, clippy
-      - name: Fetch submodules
-        run: git pull --recurse-submodules
+      - name: Update submodules
+        run: |
+          git config pull.rebase false
+          git submodule update --remote
       - name: Export environment variables
         run: |
           export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 gtk4-layer-shell:
 [![Crate](https://img.shields.io/crates/v/gtk4-layer-shell.svg)](https://crates.io/crates/gtk4-layer-shell)
 [![docs.rs](https://docs.rs/gtk4-layer-shell/badge.svg)](https://docs.rs/gtk4-layer-shell)
-[![dependency status](https://deps.rs/crate/gtk4-layer-shell/0.0.3/status.svg)](https://deps.rs/crate/gtk4-layer-shell/0.0.3)
+[![dependency status](https://deps.rs/crate/gtk4-layer-shell/0.1.0/status.svg)](https://deps.rs/crate/gtk4-layer-shell/0.1.0)
 
 gtk4-layer-shell-sys:
 [![Crate](https://img.shields.io/crates/v/gtk4-layer-shell-sys.svg)](https://crates.io/crates/gtk4-layer-shell-sys)
 [![docs.rs](https://docs.rs/gtk4-layer-shell-sys/badge.svg)](https://docs.rs/gtk4-layer-shell-sys)
-[![dependency status](https://deps.rs/crate/gtk4-layer-shell-sys/0.0.2/status.svg)](https://deps.rs/crate/gtk4-layer-shell-sys/0.0.2)
+[![dependency status](https://deps.rs/crate/gtk4-layer-shell-sys/0.1.0/status.svg)](https://deps.rs/crate/gtk4-layer-shell-sys/0.1.0)
 
 
 # gtk4-layer-shell

--- a/gtk4-layer-shell-sys/Cargo.toml
+++ b/gtk4-layer-shell-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtk4-layer-shell-sys"
-version = "0.0.2"
+version = "0.1.0"
 authors = ["pentamassiv <pentamassiv@posteo.de>"]
 license = "MIT"
 description = "Unsave gir-generated FFI bindings for gtk4-layer-shell"
@@ -26,15 +26,15 @@ libc = "0.2"
 
 [dependencies.glib]
 package = "glib-sys"
-version = "0.17"
+version = "0.18"
 
 [dependencies.gdk]
 package = "gdk4-sys"
-version = "0.6"
+version = "0.7"
 
 [dependencies.gtk]
 package = "gtk4-sys"
-version = "0.6"
+version = "0.7"
 
 [build-dependencies]
 system-deps = "6"
@@ -44,4 +44,3 @@ shell-words = "1.0.0"
 tempfile = "3"
 
 [features]
-dox = ["glib/dox", "gdk/dox", "gtk/dox"]

--- a/gtk4-layer-shell-sys/README.md
+++ b/gtk4-layer-shell-sys/README.md
@@ -6,7 +6,7 @@
 gtk4-layer-shell-sys:
 [![Crate](https://img.shields.io/crates/v/gtk4-layer-shell-sys.svg)](https://crates.io/crates/gtk4-layer-shell-sys)
 [![docs.rs](https://docs.rs/gtk4-layer-shell-sys/badge.svg)](https://docs.rs/gtk4-layer-shell-sys)
-[![dependency status](https://deps.rs/crate/gtk4-layer-shell-sys/0.0.2/status.svg)](https://deps.rs/crate/gtk4-layer-shell-sys/0.0.2)
+[![dependency status](https://deps.rs/crate/gtk4-layer-shell-sys/0.1.0/status.svg)](https://deps.rs/crate/gtk4-layer-shell-sys/0.1.0)
 
 # gtk4-layer-shell-sys
 These are the unsafe FFI bindings for [gtk4-layer-shell](https://github.com/wmww/gtk4-layer-shell). They were automatically generated from its [.gir file](../Gtk4LayerShell-1.0.gir). You need to have gtk4-layer-shell installed on your system to use this crate. Because it is new, you probably have to [build it from source](https://github.com/wmww/gtk4-layer-shell#building-from-source). If you did that, you might also have to set the following two environment variables:

--- a/gtk4-layer-shell/Cargo.toml
+++ b/gtk4-layer-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtk4-layer-shell"
-version = "0.0.3"
+version = "0.1.0"
 authors = ["pentamassiv <pentamassiv@posteo.de>"]
 license = "MIT"
 description = "Save gir-generated wrapper for gtk4-layer-shell"
@@ -11,20 +11,19 @@ categories = ["api-bindings", "gui"]
 edition = "2021"
 
 [package.metadata.docs.rs]
-features = ["dox"]
+features = []
 
 [features]
-dox = ["glib/dox", "gdk/dox", "gtk/dox"]
 
 [dependencies]
 libc = "0.2"
 bitflags = "2.0"
-glib = "0.17"
-glib-sys = "0.17"
-gdk = { package = "gdk4", version = "0.6" }
-gtk = { package = "gtk4", version = "0.6" }
-ffi = { package = "gtk4-layer-shell-sys", path = "../gtk4-layer-shell-sys", version = "0.0.2" }
+glib = "0.18"
+glib-sys = "0.18"
+gdk = { package = "gdk4", version = "0.7" }
+gtk = { package = "gtk4", version = "0.7" }
+ffi = { package = "gtk4-layer-shell-sys", path = "../gtk4-layer-shell-sys", version = "0.1" }
 
 [dev-dependencies]
-gio = "0.17"
-libadwaita = "0.4"
+gio = "0.18"
+libadwaita = "0.5"

--- a/gtk4-layer-shell/README.md
+++ b/gtk4-layer-shell/README.md
@@ -6,7 +6,7 @@
 gtk4-layer-shell:
 [![Crate](https://img.shields.io/crates/v/gtk4-layer-shell.svg)](https://crates.io/crates/gtk4-layer-shell)
 [![docs.rs](https://docs.rs/gtk4-layer-shell/badge.svg)](https://docs.rs/gtk4-layer-shell)
-[![dependency status](https://deps.rs/crate/gtk4-layer-shell/0.0.3/status.svg)](https://deps.rs/crate/gtk4-layer-shell/0.0.3)
+[![dependency status](https://deps.rs/crate/gtk4-layer-shell/0.1.0/status.svg)](https://deps.rs/crate/gtk4-layer-shell/0.1.0)
 
 # gtk4-layer-shell
 This is the safe wrapper for [gtk4-layer-shell](https://github.com/wmww/gtk4-layer-shell), automatically generated from its [.gir file](../Gtk4LayerShell-1.0.gir). The unsafe bindings can be found [here](https://github.com/pentamassiv/gtk4-layer-shell-gir/tree/main/gtk4-layer-shell-sys). You need to have gtk4-layer-shell installed on your system to use this crate. Because it is new, you probably have to [build it from source](https://github.com/wmww/gtk4-layer-shell#building-from-source). If you did that, you might also have to set the following two environment variables:


### PR DESCRIPTION
The code generated by gir used to have a dox feature which allowed building the docs without linking to libraries. This allowed building the docs on docs.rs for example. This feature is no longer needed and thus was removed.
Removing the feature required a bump in the minor version.
I also bumped the dependencies to their newest versions.