### PR TITLE
Add workflow to publish new versions on crates.io

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,68 @@
+name: Publish
+
+permissions:
+  contents: write
+on:
+  workflow_dispatch:
+    inputs:
+      crate_type:
+        type: choice
+        description: Which crate to publish?
+        options:
+          - sys
+          - wrapper
+        required: true
+      version:
+        description: "New version of the crate"
+        required: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "true"
+      - uses: ./.github/actions/install_deps
+      - uses: dtolnay/rust-toolchain@master
+        with:
+            toolchain: nightly
+            components: rustfmt, clippy
+      - name: "Set the path"
+        run: |
+          if [[ ${{ github.event.inputs.crate_type }} == 'sys' ]]; then
+            echo "CRATE_PATH=gtk4-layer-shell-sys" >> "$GITHUB_ENV"
+          elif [[ ${{ github.event.inputs.crate_type }} == 'wrapper' ]]; then
+            echo "CRATE_PATH=gtk4-layer-shell" >> "$GITHUB_ENV"
+          else
+            exit 1
+          fi
+      - name: Get the version number
+        id: previous_version
+        run: |
+          echo "PREVIOUS_VERSION=$(grep -o -m 1 -P '(?<=version = ").*(?=")' ./${{ env.CRATE_PATH }}/Cargo.toml)" >> $GITHUB_OUTPUT
+      - name: Output the version numbers
+        run: |
+          echo "Previous version: ${{ steps.previous_version.outputs.PREVIOUS_VERSION }}"
+          echo "New version: ${{ github.event.inputs.version }}"
+      - name: Bump version number in Cargo.toml
+        run: |
+          sed -i '0,/version = "${{ steps.previous_version.outputs.PREVIOUS_VERSION }}"/{s//version = "${{ github.event.inputs.version }}"/}' ./${{ env.CRATE_PATH }}/Cargo.toml
+      - name: Bump version of badge in README.md
+        run: |
+          sed -i '0,/${{ env.CRATE_PATH }}\/${{ steps.previous_version.outputs.PREVIOUS_VERSION }}/{s//${{ env.CRATE_PATH }}\/${{ github.event.inputs.version }}/}' ./${{ env.CRATE_PATH }}/README.md
+          sed -i '0,/${{ env.CRATE_PATH }}\/${{ steps.previous_version.outputs.PREVIOUS_VERSION }}/{s//${{ env.CRATE_PATH }}\/${{ github.event.inputs.version }}/}' ./${{ env.CRATE_PATH }}/README.md
+      - name: Bump version of badge in repo README.md
+        run: |
+          sed -i '0,/${{ env.CRATE_PATH }}\/${{ steps.previous_version.outputs.PREVIOUS_VERSION }}/{s//${{ env.CRATE_PATH }}\/${{ github.event.inputs.version }}/}' ./README.md
+          sed -i '0,/${{ env.CRATE_PATH }}\/${{ steps.previous_version.outputs.PREVIOUS_VERSION }}/{s//${{ env.CRATE_PATH }}\/${{ github.event.inputs.version }}/}' ./README.md
+      - name: Commit the changes to repo
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Bump version number of ${{ github.event.inputs.crate_type }} crate and publish it
+      - name: Publish on crates.io
+        working-directory: ./${{ env.CRATE_PATH }}
+        run: cargo publish --token ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
I don't always have all libs installed on my system to be able to publish new versions so it's easier to have the Github Actions publish it