### PR TITLE
Moved all functions to the new trait `LayerShell`

### DIFF
--- a/.github/actions/build_test_commit/action.yaml
+++ b/.github/actions/build_test_commit/action.yaml
@@ -27,10 +27,10 @@ runs:
         cargo build --verbose --all-features
         cargo test --verbose
         cargo doc --all-features
-    - name: Build the example
+    - name: Build the examples
       working-directory: ./gtk4-layer-shell/
       shell: bash
-      run: cargo build --example simple-example
+      run: cargo build --examples
     - name: Count the number of files other than the versions.txt files, which were changed
       id: changed_files
       shell: bash

--- a/gtk4-layer-shell-sys/README.md
+++ b/gtk4-layer-shell-sys/README.md
@@ -44,7 +44,7 @@ cargo test     # Test the created bindings
 cd ..
 ```
 
-There should not have been any errors. If you do encounter an error complaining about the `dox` feature not being available for the `gtk4` crate, you have to change the name of the `gtk4` crate in the `Cargo.toml` file. You should now continue and generate the [safe wrapper](https://github.com/pentamassiv/gtk4-layer-shell-gir/tree/main/gtk4-layer-shell/README.md#generating-the-wrapper).
+There should not have been any errors. You should now continue and generate the [safe wrapper](https://github.com/pentamassiv/gtk4-layer-shell-gir/tree/main/gtk4-layer-shell/README.md#generating-the-wrapper).
 If you want to learn more about gir, have a look at its [repo](https://github.com/gtk-rs/gir) or its [book](https://gtk-rs.org/gir/book/).
 
 ## Maintenance status

--- a/gtk4-layer-shell/Cargo.toml
+++ b/gtk4-layer-shell/Cargo.toml
@@ -31,6 +31,7 @@ ffi = { package = "gtk4-layer-shell-sys", path = "../gtk4-layer-shell-sys", vers
 [dev-dependencies]
 gio = "0.18"
 libadwaita = "0.5"
+relm4 = "0.7.0-alpha.1" # TODO: Switch to 0.7 as soon as it is available
 
 [target.'cfg(docsrs)'.dependencies]
 gdk = { package = "gdk4", version = "0.7", features = ["gl", "v4_12"] }

--- a/gtk4-layer-shell/examples/libadwaita.rs
+++ b/gtk4-layer-shell/examples/libadwaita.rs
@@ -6,6 +6,7 @@ use libadwaita as adw;
 use adw::prelude::*;
 use adw::{ActionRow, ApplicationWindow, HeaderBar};
 use gtk::{Application, Box, ListBox, Orientation};
+use gtk4_layer_shell::{Edge, Layer, LayerShell};
 
 fn main() {
     let application = Application::builder()
@@ -58,24 +59,24 @@ fn main() {
         // Part that is specific to use gtk4-layer-shell begins
 
         // Before the window is first realized, set it up to be a layer surface
-        gtk4_layer_shell::init_for_window(&window);
+        window.init_layer_shell();
 
         // Display above normal windows
-        gtk4_layer_shell::set_layer(&window, gtk4_layer_shell::Layer::Overlay);
+        window.set_layer(Layer::Overlay);
 
         // Push other windows out of the way
-        gtk4_layer_shell::auto_exclusive_zone_enable(&window);
+        window.auto_exclusive_zone_enable();
 
         // Anchors are if the window is pinned to each edge of the output
         let anchors = [
-            (gtk4_layer_shell::Edge::Left, true),
-            (gtk4_layer_shell::Edge::Right, true),
-            (gtk4_layer_shell::Edge::Top, false),
-            (gtk4_layer_shell::Edge::Bottom, true),
+            (Edge::Left, true),
+            (Edge::Right, true),
+            (Edge::Top, false),
+            (Edge::Bottom, true),
         ];
 
         for (anchor, state) in anchors {
-            gtk4_layer_shell::set_anchor(&window, anchor, state);
+            window.set_anchor(anchor, state);
         }
         // Part that is specific to use gtk4-layer-shell ends
         // #################################

--- a/gtk4-layer-shell/examples/relm4.rs
+++ b/gtk4-layer-shell/examples/relm4.rs
@@ -1,0 +1,88 @@
+// This is based on the simple example of the relm4 repo and is meant to showcase how easily this library can be used with relm4
+
+use gtk::prelude::*;
+use gtk4_layer_shell::{Edge, Layer, LayerShell}; // Import the additional types
+use relm4::prelude::*;
+
+struct App {
+    counter: u8,
+}
+
+#[derive(Debug)]
+enum Msg {
+    Increment,
+    Decrement,
+}
+
+#[relm4::component]
+impl SimpleComponent for App {
+    type Init = u8;
+    type Input = Msg;
+    type Output = ();
+
+    view! {
+        gtk::Window {
+            init_layer_shell: (), // Do gtk4_layer_shell stuff here
+            set_layer: Layer::Overlay,
+            auto_exclusive_zone_enable: (),
+            set_margin: (Edge::Left, 40),
+            set_anchor: (Edge::Right, true),
+            set_anchor: (Edge::Top, false),
+            set_anchor: (Edge::Bottom, true),
+            set_title: Some("Simple app"),
+            set_default_size: (300, 100),
+
+            gtk::Box {
+                set_orientation: gtk::Orientation::Vertical,
+                set_spacing: 5,
+                set_margin_all: 5,
+
+                gtk::Button {
+                    set_label: "Increment",
+                    connect_clicked => Msg::Increment,
+                },
+
+                gtk::Button {
+                    set_label: "Decrement",
+                    connect_clicked => Msg::Decrement,
+                },
+
+                gtk::Label {
+                    #[watch]
+                    set_label: &format!("Counter: {}", model.counter),
+                    set_margin_all: 5,
+                }
+            }
+        }
+    }
+
+    // Initialize the component.
+    fn init(
+        counter: Self::Init,
+        root: &Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let model = App { counter };
+
+        // Insert the code generation of the view! macro here
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, msg: Self::Input, _sender: ComponentSender<Self>) {
+        match msg {
+            Msg::Increment => {
+                self.counter = self.counter.wrapping_add(1);
+            }
+            Msg::Decrement => {
+                self.counter = self.counter.wrapping_sub(1);
+            }
+        }
+    }
+}
+
+fn main() {
+    let app = RelmApp::new("relm4.example.simple");
+    app.run::<App>(0);
+}

--- a/gtk4-layer-shell/examples/simple-example.rs
+++ b/gtk4-layer-shell/examples/simple-example.rs
@@ -1,5 +1,6 @@
 use gio::prelude::*;
 use gtk::prelude::*;
+use gtk4_layer_shell::{Edge, Layer, LayerShell};
 
 // https://github.com/wmww/gtk-layer-shell/blob/master/examples/simple-example.c
 fn activate(application: &gtk::Application) {
@@ -7,31 +8,31 @@ fn activate(application: &gtk::Application) {
     let window = gtk::ApplicationWindow::new(application);
 
     // Before the window is first realized, set it up to be a layer surface
-    gtk4_layer_shell::init_for_window(&window);
+    window.init_layer_shell();
 
     // Display above normal windows
-    gtk4_layer_shell::set_layer(&window, gtk4_layer_shell::Layer::Overlay);
+    window.set_layer(Layer::Overlay);
 
     // Push other windows out of the way
-    gtk4_layer_shell::auto_exclusive_zone_enable(&window);
+    window.auto_exclusive_zone_enable();
 
     // The margins are the gaps around the window's edges
     // Margins and anchors can be set like this...
-    gtk4_layer_shell::set_margin(&window, gtk4_layer_shell::Edge::Left, 40);
-    gtk4_layer_shell::set_margin(&window, gtk4_layer_shell::Edge::Right, 40);
-    gtk4_layer_shell::set_margin(&window, gtk4_layer_shell::Edge::Top, 20);
+    window.set_margin(Edge::Left, 40);
+    window.set_margin(Edge::Right, 40);
+    window.set_margin(Edge::Top, 20);
 
     // ... or like this
     // Anchors are if the window is pinned to each edge of the output
     let anchors = [
-        (gtk4_layer_shell::Edge::Left, true),
-        (gtk4_layer_shell::Edge::Right, true),
-        (gtk4_layer_shell::Edge::Top, false),
-        (gtk4_layer_shell::Edge::Bottom, true),
+        (Edge::Left, true),
+        (Edge::Right, true),
+        (Edge::Top, false),
+        (Edge::Bottom, true),
     ];
 
     for (anchor, state) in anchors {
-        gtk4_layer_shell::set_anchor(&window, anchor, state);
+        window.set_anchor(anchor, state);
     }
 
     // Set up a widget

--- a/gtk4-layer-shell/src/lib.rs
+++ b/gtk4-layer-shell/src/lib.rs
@@ -1,6 +1,12 @@
-#![cfg_attr(feature = "dox", feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(warnings)]
-#![allow(clippy::single_component_path_imports)]
+#![allow(rustdoc::redundant_explicit_links)]
+
+#[allow(unused_imports)]
+#[allow(clippy::single_component_path_imports)]
+use gtk; // Required for the documentation to build without warnings
+
+use gtk::prelude::IsA;
 
 macro_rules! assert_initialized_main_thread {
     () => {
@@ -19,13 +25,273 @@ macro_rules! skip_assert_initialized {
     () => {};
 }
 
-#[allow(unused_imports)]
-use gtk; // Required for the documentation to build without warnings
-
 mod auto;
-
-pub use auto::functions::*;
-pub use auto::*;
+pub use auto::{
+    functions::is_supported, functions::major_version, functions::micro_version,
+    functions::minor_version, functions::protocol_version, Edge, KeyboardMode, Layer,
+};
 
 mod manual;
-pub use manual::*;
+//use manual::*;
+
+pub trait LayerShell: IsA<gtk::Window> {
+    /// When auto exclusive zone is enabled, exclusive zone is automatically set to the
+    /// size of the `window` + relevant margin. To disable auto exclusive zone, just set the
+    /// exclusive zone to 0 or any other fixed value.
+    ///
+    /// NOTE: you can control the auto exclusive zone by changing the margin on the non-anchored
+    /// edge. This behavior is specific to gtk-layer-shell and not part of the underlying protocol
+    /// ## `window`
+    /// A layer surface.
+    #[doc(alias = "gtk_layer_auto_exclusive_zone_enable")]
+    fn auto_exclusive_zone_enable(&self) {
+        crate::auto::functions::auto_exclusive_zone_enable(self);
+    }
+
+    /// ## `window`
+    /// A layer surface.
+    ///
+    /// # Returns
+    ///
+    /// if the surface's exclusive zone is set to change based on the window's size
+    #[doc(alias = "gtk_layer_auto_exclusive_zone_is_enabled")]
+    fn auto_exclusive_zone_is_enabled(&self) -> bool {
+        crate::auto::functions::auto_exclusive_zone_is_enabled(self)
+    }
+
+    /// ## `window`
+    /// A layer surface.
+    /// ## `edge`
+    /// the edge to which the surface may or may not be anchored
+    ///
+    /// # Returns
+    ///
+    /// if this surface is anchored to the given edge.
+    #[doc(alias = "gtk_layer_get_anchor")]
+    #[doc(alias = "get_anchor")]
+    fn is_anchor(&self, edge: Edge) -> bool {
+        crate::auto::functions::is_anchor(self, edge)
+    }
+
+    /// ## `window`
+    /// A layer surface.
+    ///
+    /// # Returns
+    ///
+    /// the window's exclusive zone (which may have been set manually or automatically)
+    #[doc(alias = "gtk_layer_get_exclusive_zone")]
+    #[doc(alias = "get_exclusive_zone")]
+    fn exclusive_zone(&self) -> i32 {
+        crate::auto::functions::exclusive_zone(self)
+    }
+
+    /// ## `window`
+    /// A layer surface.
+    ///
+    /// # Returns
+    ///
+    /// current keyboard interactivity mode for `window`.
+    #[doc(alias = "gtk_layer_get_keyboard_mode")]
+    #[doc(alias = "get_keyboard_mode")]
+    fn keyboard_mode(&self) -> KeyboardMode {
+        crate::auto::functions::keyboard_mode(self)
+    }
+
+    /// ## `window`
+    /// A layer surface.
+    ///
+    /// # Returns
+    ///
+    /// the current layer.
+    #[doc(alias = "gtk_layer_get_layer")]
+    #[doc(alias = "get_layer")]
+    fn layer(&self) -> Layer {
+        crate::auto::functions::layer(self)
+    }
+
+    /// ## `window`
+    /// A layer surface.
+    /// ## `edge`
+    /// the margin edge to get
+    ///
+    /// # Returns
+    ///
+    /// the size of the margin for the given edge.
+    #[doc(alias = "gtk_layer_get_margin")]
+    #[doc(alias = "get_margin")]
+    fn margin(&self, edge: Edge) -> i32 {
+        crate::auto::functions::margin(self, edge)
+    }
+
+    /// NOTE: To get which monitor the surface is actually on, use
+    /// `gdk_display_get_monitor_at_window()`.
+    /// ## `window`
+    /// A layer surface.
+    ///
+    /// # Returns
+    ///
+    /// the monitor this surface will/has requested to be on, can be [`None`].
+    #[doc(alias = "gtk_layer_get_monitor")]
+    #[doc(alias = "get_monitor")]
+    fn monitor(&self) -> Option<gdk::Monitor> {
+        crate::auto::functions::monitor(self)
+    }
+
+    /// NOTE: this function does not return ownership of the string. Do not free the returned string.
+    /// Future calls into the library may invalidate the returned string.
+    /// ## `window`
+    /// A layer surface.
+    ///
+    /// # Returns
+    ///
+    /// a reference to the namespace property. If namespace is unset, returns the
+    /// default namespace ("gtk-layer-shell"). Never returns [`None`].
+    #[doc(alias = "gtk_layer_get_namespace")]
+    #[doc(alias = "get_namespace")]
+    fn namespace(&self) -> Option<glib::GString> {
+        crate::auto::functions::namespace(self)
+    }
+
+    /// Set the `window` up to be a layer surface once it is mapped. this must be called before
+    /// the `window` is realized.
+    /// ## `window`
+    /// A [`gtk::Window`][crate::gtk::Window] to be turned into a layer surface.
+    #[doc(alias = "init_for_window")]
+    #[doc(alias = "gtk_layer_init_for_window")]
+    fn init_layer_shell(&self) {
+        crate::auto::functions::init_for_window(self);
+    }
+
+    /// ## `window`
+    /// A [`gtk::Window`][crate::gtk::Window] that may or may not have a layer surface.
+    ///
+    /// # Returns
+    ///
+    /// if `window` has been initialized as a layer surface.
+    #[doc(alias = "gtk_layer_is_layer_window")]
+    fn is_layer_window(&self) -> bool {
+        crate::auto::functions::is_layer_window(self)
+    }
+
+    /// Set whether `window` should be anchored to `edge`.
+    /// - If two perpendicular edges are anchored, the surface with be anchored to that corner
+    /// - If two opposite edges are anchored, the window will be stretched across the screen in that direction
+    ///
+    /// Default is [`false`] for each [`Edge`][crate::Edge]
+    /// ## `window`
+    /// A layer surface.
+    /// ## `edge`
+    /// A [`Edge`][crate::Edge] this layer surface may be anchored to.
+    /// ## `anchor_to_edge`
+    /// Whether or not to anchor this layer surface to `edge`.
+    #[doc(alias = "gtk_layer_set_anchor")]
+    fn set_anchor(&self, edge: Edge, anchor_to_edge: bool) {
+        crate::auto::functions::set_anchor(self, edge, anchor_to_edge);
+    }
+
+    /// Has no effect unless the surface is anchored to an edge. Requests that the compositor
+    /// does not place other surfaces within the given exclusive zone of the anchored edge.
+    /// For example, a panel can request to not be covered by maximized windows. See
+    /// wlr-layer-shell-unstable-v1.xml for details.
+    ///
+    /// Default is 0
+    /// ## `window`
+    /// A layer surface.
+    /// ## `exclusive_zone`
+    /// The size of the exclusive zone.
+    #[doc(alias = "gtk_layer_set_exclusive_zone")]
+    fn set_exclusive_zone(&self, exclusive_zone: i32) {
+        crate::auto::functions::set_exclusive_zone(self, exclusive_zone);
+    }
+
+    /// Sets if/when `window` should receive keyboard events from the compositor, see
+    /// GtkLayerShellKeyboardMode for details.
+    ///
+    /// Default is [`KeyboardMode::None`][crate::KeyboardMode::None]
+    /// ## `window`
+    /// A layer surface.
+    /// ## `mode`
+    /// The type of keyboard interactivity requested.
+    #[doc(alias = "gtk_layer_set_keyboard_mode")]
+    fn set_keyboard_mode(&self, mode: KeyboardMode) {
+        crate::auto::functions::set_keyboard_mode(self, mode);
+    }
+
+    /// Set the "layer" on which the surface appears (controls if it is over top of or below other surfaces). The layer may
+    /// be changed on-the-fly in the current version of the layer shell protocol, but on compositors that only support an
+    /// older version the `window` is remapped so the change can take effect.
+    ///
+    /// Default is [`Layer::Top`][crate::Layer::Top]
+    /// ## `window`
+    /// A layer surface.
+    /// ## `layer`
+    /// The layer on which this surface appears.
+    #[doc(alias = "gtk_layer_set_layer")]
+    fn set_layer(&self, layer: Layer) {
+        crate::auto::functions::set_layer(self, layer);
+    }
+
+    /// Set the margin for a specific `edge` of a `window`. Effects both surface's distance from
+    /// the edge and its exclusive zone size (if auto exclusive zone enabled).
+    ///
+    /// Default is 0 for each [`Edge`][crate::Edge]
+    /// ## `window`
+    /// A layer surface.
+    /// ## `edge`
+    /// The [`Edge`][crate::Edge] for which to set the margin.
+    /// ## `margin_size`
+    /// The margin for `edge` to be set.
+    #[doc(alias = "gtk_layer_set_margin")]
+    fn set_margin(&self, edge: Edge, margin_size: i32) {
+        crate::auto::functions::set_margin(self, edge, margin_size);
+    }
+
+    /// Set the output for the window to be placed on, or [`None`] to let the compositor choose.
+    /// If the window is currently mapped, it will get remapped so the change can take effect.
+    ///
+    /// Default is [`None`]
+    /// ## `window`
+    /// A layer surface.
+    /// ## `monitor`
+    /// The output this layer surface will be placed on ([`None`] to let the compositor decide).
+    #[doc(alias = "gtk_layer_set_monitor")]
+    fn set_monitor(&self, monitor: &gdk::Monitor) {
+        crate::auto::functions::set_monitor(self, monitor);
+    }
+
+    /// Set the "namespace" of the surface.
+    ///
+    /// No one is quite sure what this is for, but it probably should be something generic
+    /// ("panel", "osk", etc). The `name_space` string is copied, and caller maintains
+    /// ownership of original. If the window is currently mapped, it will get remapped so
+    /// the change can take effect.
+    ///
+    /// Default is "gtk-layer-shell" (which will be used if set to [`None`])
+    /// ## `window`
+    /// A layer surface.
+    /// ## `name_space`
+    /// The namespace of this layer surface.
+    #[doc(alias = "gtk_layer_set_namespace")]
+    fn set_namespace(&self, name_space: &str) {
+        crate::auto::functions::set_namespace(self, name_space);
+    }
+
+    /* TODO: Fix this
+    /// ## `window`
+    /// A layer surface.
+    ///
+    /// # Returns
+    ///
+    /// The underlying layer surface Wayland object
+    ///
+    #[doc(alias = "gtk_layer_get_zwlr_layer_surface_v1")]
+    #[doc(alias = "get_zwlr_layer_surface_v1")]
+    fn zwlr_layer_surface_v1(
+        window: &impl glib::object::IsA<gtk::Window>,
+    ) -> *mut ZwlrLayerSurfaceV1 {
+        zwlr_layer_surface_v1(self)
+    }*/
+}
+
+// The default implementation is always fine
+impl<T: IsA<gtk::Window>> LayerShell for T {}

--- a/gtk4-layer-shell/src/manual.rs
+++ b/gtk4-layer-shell/src/manual.rs
@@ -1,3 +1,4 @@
+/*
 pub type ZwlrLayerSurfaceV1 = ffi::zwlr_layer_surface_v1;
 
 /// ## `window`
@@ -6,8 +7,6 @@ pub type ZwlrLayerSurfaceV1 = ffi::zwlr_layer_surface_v1;
 /// # Returns
 ///
 /// The underlying layer surface Wayland object
-#[cfg(any(feature = "v0_4", feature = "dox"))]
-#[cfg_attr(feature = "dox", doc(cfg(feature = "v0_4")))]
 #[doc(alias = "gtk_layer_get_zwlr_layer_surface_v1")]
 #[doc(alias = "get_zwlr_layer_surface_v1")]
 pub fn zwlr_layer_surface_v1(
@@ -18,3 +17,4 @@ pub fn zwlr_layer_surface_v1(
     assert_initialized_main_thread!();
     unsafe { ffi::gtk_layer_get_zwlr_layer_surface_v1(window.as_ref().to_glib_none().0) }
 }
+*/


### PR DESCRIPTION
In order to make it easier for this library to work with relm4 and have to code look rustier, I added a new trait called `LayerShell`. Checkout the `simple-example` to see how to use this library now. Only small changes will be needed and the code looks much better.