### PR TITLE
Add support for gtk4-session-lock

### DIFF
--- a/.github/actions/build_test_commit/action.yaml
+++ b/.github/actions/build_test_commit/action.yaml
@@ -10,56 +10,69 @@ runs:
   using: "composite"
   steps:
     - name: Build and test the sys crate
-      working-directory: ./gtk4-layer-shell-sys
       shell: bash
       run: |
-        ls
         export PATH=$PATH:/github/home/.cargo/bin
-        # Test if there is any output to the gir command
-        if [[ $(gir -o . |& wc -l) -ne 0 ]]; then 
-          echo "gir -o failed"
-          exit 1
-        fi
-        cargo update
-        cargo build --verbose --all-features
-        cargo test --verbose
-        cargo doc --all-features
+        
+        folders=("gtk4-layer-shell" "gtk4-session-lock")
+        for folder in "${folders[@]}"; do
+          echo "Processing sys crate: ${folder}-sys"
+          cd "${folder}-sys" || exit 1
+          ls
+          # Test if there is any output to the gir command
+          if [[ $(gir -o . |& wc -l) -ne 0 ]]; then 
+            echo "gir -o failed"
+            exit 1
+          fi
+          cargo update
+          cargo build --verbose --all-features
+          cargo test --verbose
+          cargo doc --all-features
+          cd ..
+        done
     # Exit with an error if there is any output of the gir commands, because then there might be some wrongly generated code or errors
     - name: Build and test the wrapper crate
       shell: bash
-      working-directory: ./gtk4-layer-shell/
       run: |
-        ls
         export PATH=$PATH:/github/home/.cargo/bin
-        if [[ $(gir -o . |& wc -l) -ne 0 ]]; then
-          echo "gir -o failed"
-          exit 1
-        fi
-        if [[ $(gir -o . -m not_bound |& wc -l) -ne 0 ]]; then
-          echo "gir not_bound failed"
-          exit 1
-        fi
-        # Check if the docs were generated without a warning
-        if [[ $(gir -c Gir.toml --doc-target-path docs.md -m doc |& wc -l) -ne 0 ]]; then
-          echo "gir docs failed"
-          exit 1
-        fi
-        cargo install rustdoc-stripper --force
-        rustdoc-stripper -s -n
-        rustdoc-stripper -g -o docs.md
-        cargo update
-        cargo build --verbose --all-features
-        cargo test --verbose
-        cargo doc --all-features
-    - name: Build the examples
-      working-directory: ./gtk4-layer-shell/
-      shell: bash
-      run: cargo build --examples
+        folders=("gtk4-layer-shell" "gtk4-session-lock")
+        for folder in "${folders[@]}"; do
+          echo "Processing wrapper crate: ${folder}"
+          cd "${folder}" || exit 1
+          ls
+          # Test gir commands
+          if [[ $(gir -o . |& wc -l) -ne 0 ]]; then
+            echo "gir -o failed"
+            exit 1
+          fi
+          if [[ $(gir -o . -m not_bound |& wc -l) -ne 0 ]]; then
+            echo "gir not_bound failed"
+            exit 1
+          fi
+          # Check if the docs were generated without a warning
+          if [[ $(gir -c Gir.toml --doc-target-path docs.md -m doc |& wc -l) -ne 0 ]]; then
+            echo "gir docs failed"
+            exit 1
+          fi
+          # Documentation processing
+          cargo install rustdoc-stripper --force
+          rustdoc-stripper -s -n
+          rustdoc-stripper -g -o docs.md
+          # Build and test
+          cargo update
+          cargo build --verbose --all-features
+          cargo test --verbose
+          cargo doc --all-features
+          # Build examples
+          cargo build --examples --all-features
+          cd ..
+        done
     - name: Count the number of files other than the versions.txt files, which were changed
       id: changed_files
       shell: bash
       if: ${{ inputs.commit_message != '' }}
-      run: echo "NO_CHANGED_FILES=$(git diff --name-only -- . ':(exclude)gtk4-layer-shell/src/auto/versions.txt' ':(exclude)gtk4-layer-shell-sys/src/auto/versions.txt' ':(exclude)gir' | wc -l)" >> $GITHUB_OUTPUT
+      run: |
+        echo "NO_CHANGED_FILES=$(git diff --ignore-submodules --name-only -- . ':(exclude)*/src/auto/versions.txt' ':(exclude)gir' | wc -l)" >> $GITHUB_OUTPUT
     - name: Commit code changes to main
       if: inputs.commit_message != '' && steps.changed_files.outputs.NO_CHANGED_FILES != '0'
       uses: stefanzweifel/git-auto-commit-action@v5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = ["gtk4-layer-shell", "gtk4-layer-shell-sys"]
+members = [
+  "gtk4-layer-shell",
+  "gtk4-layer-shell-sys",
+  "gtk4-session-lock",
+  "gtk4-session-lock-sys",
+]
 exclude = ["gir"]
 resolver = "2"
 
@@ -18,6 +23,7 @@ gio = "0.20"
 gdk4-sys = "0.9"
 gdk = { package = "gdk4", version = "0.9" }
 gtk4-sys = "0.9"
+gobject-sys = "0.20"
 gtk = { package = "gtk4", version = "0.9" }
 system-deps = "7"
 shell-words = "1.0"
@@ -25,3 +31,4 @@ tempfile = "3"
 libadwaita = "0.7"
 relm4 = "0.9"
 gtk4-layer-shell-sys = { path = "gtk4-layer-shell-sys", version = "0.3" }
+gtk4-session-lock-sys = { path = "gtk4-session-lock-sys", version = "0.1" }

--- a/Gtk4SessionLock-1.0.gir
+++ b/Gtk4SessionLock-1.0.gir
@@ -1,0 +1,192 @@
+<?xml version="1.0"?>
+<!-- This file was automatically generated from C sources - DO NOT EDIT!
+To affect the contents of this file, edit the original C definitions,
+and/or use gtk-doc annotations.  -->
+<repository version="1.2"
+            xmlns="http://www.gtk.org/introspection/core/1.0"
+            xmlns:c="http://www.gtk.org/introspection/c/1.0"
+            xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+  <include name="Gtk" version="4.0"/>
+  <package name="gtk4-layer-shell-0"/>
+  <c:include name="gtk4-session-lock.h"/>
+  <namespace name="Gtk4SessionLock"
+             version="1.0"
+             shared-library="libgtk4-layer-shell.so.0"
+             c:identifier-prefixes="GtkSessionLock"
+             c:symbol-prefixes="gtk_session_lock">
+    <class name="Instance"
+           c:symbol-prefix="instance"
+           c:type="GtkSessionLockInstance"
+           parent="GObject.Object"
+           glib:type-name="GtkSessionLockInstance"
+           glib:get-type="gtk_session_lock_instance_get_type"
+           glib:type-struct="InstanceClass">
+      <doc xml:space="preserve"
+           filename="include/gtk4-session-lock.h"
+           line="39">An instance of the object used to control locking the screen.
+Multiple instances can exist at once, but only one can be locked at a time.</doc>
+      <source-position filename="include/gtk4-session-lock.h" line="46"/>
+      <constructor name="new" c:identifier="gtk_session_lock_instance_new">
+        <source-position filename="include/gtk4-session-lock.h" line="72"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve"
+               filename="include/gtk4-session-lock.h"
+               line="70">new session lock instance</doc>
+          <type name="Instance" c:type="GtkSessionLockInstance*"/>
+        </return-value>
+      </constructor>
+      <method name="assign_window_to_monitor"
+              c:identifier="gtk_session_lock_instance_assign_window_to_monitor">
+        <doc xml:space="preserve"
+             filename="include/gtk4-session-lock.h"
+             line="103">This must be called with a different window once for each monitor, immediately after calling
+gtk_session_lock_lock(). Hiding a window that is active on a monitor or not letting a window be resized by the
+library is not allowed (may result in a Wayland protocol error).</doc>
+        <source-position filename="include/gtk4-session-lock.h" line="113"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="include/gtk4-session-lock.h"
+                 line="105">the instance to use</doc>
+            <type name="Instance" c:type="GtkSessionLockInstance*"/>
+          </instance-parameter>
+          <parameter name="window" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="include/gtk4-session-lock.h"
+                 line="106">The GTK Window to use as a lock surface</doc>
+            <type name="Gtk.Window" c:type="GtkWindow*"/>
+          </parameter>
+          <parameter name="monitor" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="include/gtk4-session-lock.h"
+                 line="107">The monitor to show it on</doc>
+            <type name="Gdk.Monitor" c:type="GdkMonitor*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="is_locked"
+              c:identifier="gtk_session_lock_instance_is_locked">
+        <doc xml:space="preserve"
+             filename="include/gtk4-session-lock.h"
+             line="95">Returns if this instance currently holds a lock.</doc>
+        <source-position filename="include/gtk4-session-lock.h" line="101"/>
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="include/gtk4-session-lock.h"
+                 line="97">the instance</doc>
+            <type name="Instance" c:type="GtkSessionLockInstance*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="lock" c:identifier="gtk_session_lock_instance_lock">
+        <doc xml:space="preserve"
+             filename="include/gtk4-session-lock.h"
+             line="74">Lock the screen. This should be called before assigning any windows to monitors. If this function fails the ::failed
+signal is emitted, if it succeeds the ::locked signal is emitted. The ::failed signal may be emitted before the
+function returns (for example, if another #GtkSessionLockInstance holds a lock) or later (if another process holds a
+lock). The only case where neither signal is triggered is if the instance is already locked.</doc>
+        <source-position filename="include/gtk4-session-lock.h" line="85"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="include/gtk4-session-lock.h"
+               line="83">false on immediate fail, true if lock acquisition was successfully started</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="include/gtk4-session-lock.h"
+                 line="76">the instance to lock</doc>
+            <type name="Instance" c:type="GtkSessionLockInstance*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="unlock" c:identifier="gtk_session_lock_instance_unlock">
+        <doc xml:space="preserve"
+             filename="include/gtk4-session-lock.h"
+             line="87">If the screen is locked by this instance unlocks it and fires ::unlocked. Otherwise has no effect</doc>
+        <source-position filename="include/gtk4-session-lock.h" line="93"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="include/gtk4-session-lock.h"
+                 line="89">the instance to unlock</doc>
+            <type name="Instance" c:type="GtkSessionLockInstance*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <glib:signal name="failed" when="first">
+        <doc xml:space="preserve"
+             filename="include/gtk4-session-lock.h"
+             line="54">The ::failed signal is fired when the lock could not be acquired.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+      <glib:signal name="locked" when="first">
+        <doc xml:space="preserve"
+             filename="include/gtk4-session-lock.h"
+             line="48">The ::locked signal is fired when the screen is successfully locked.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+      <glib:signal name="unlocked" when="first">
+        <doc xml:space="preserve"
+             filename="include/gtk4-session-lock.h"
+             line="60">The ::unlocked signal is fired when the session is unlocked, which may have been caused by a call to
+gtk_session_lock_instance_unlock() or by the compositor.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+    </class>
+    <record name="InstanceClass"
+            c:type="GtkSessionLockInstanceClass"
+            glib:is-gtype-struct-for="Instance">
+      <source-position filename="include/gtk4-session-lock.h" line="46"/>
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+    </record>
+    <docsection name="gtk4-session-lock">
+      <doc xml:space="preserve"
+           filename="include/gtk4-session-lock.h"
+           line="6">[Session Lock](https://wayland.app/protocols/ext-session-lock-v1)
+is a Wayland protocol for lock screens. Use it to lock the compositor
+and display the lock screen. This library and the underlying Wayland
+protocol do not handle authentication.
+
+# Note on popups
+Popups (such as menus and tooltips) do not currently display while the screen is locked. Please use alternatives,
+such as GtkPopover (which is backed by a subsurface instead of a popup).
+
+# Note On Linking
+If you link against libwayland you must link this library before libwayland. See
+[linking.md](https://github.com/wmww/gtk4-layer-shell/blob/main/linking.md) for details.</doc>
+    </docsection>
+    <function name="is_supported" c:identifier="gtk_session_lock_is_supported">
+      <doc xml:space="preserve"
+           filename="include/gtk4-session-lock.h"
+           line="29">May block for a Wayland roundtrip the first time it's called.</doc>
+      <source-position filename="include/gtk4-session-lock.h" line="37"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve"
+             filename="include/gtk4-session-lock.h"
+             line="34">%TRUE if the platform is Wayland and Wayland compositor supports the
+Session Lock protocol.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+    </function>
+  </namespace>
+</repository>

--- a/gtk4-session-lock-sys/Cargo.toml
+++ b/gtk4-session-lock-sys/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "gtk4-session-lock-sys"
+version = "0.1.0"
+edition = "2021"
+build = "build.rs"
+
+[package.metadata.system-deps.gtk4_layer_shell_0]
+name = "gtk4-layer-shell-0"
+version = "1"
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
+all-features = true
+
+[lib]
+name = "gtk4_session_lock_sys"
+
+[dependencies]
+libc = "0.2"
+
+[dependencies.glib-sys]
+workspace = true
+
+[dependencies.gdk4-sys]
+workspace = true
+
+[dependencies.gobject-sys]
+workspace = true
+
+[dependencies.gtk4-sys]
+workspace = true
+
+[build-dependencies]
+system-deps = "7"
+
+[dev-dependencies]
+shell-words = "1.0.0"
+tempfile = "3"
+
+[features]

--- a/gtk4-session-lock-sys/Gir.toml
+++ b/gtk4-session-lock-sys/Gir.toml
@@ -1,0 +1,14 @@
+[options]
+library = "Gtk4SessionLock"
+version = "1.0"
+target_path = "."
+min_cfg_version = "1.0"
+work_mode = "sys"
+girs_directories = ["../gir-files", ".."]
+single_version_file = true
+
+external_libraries = ["GLib", "GObject"]
+
+[external_libraries]
+gdk4 = "Gdk"
+gtk4 = "Gtk"

--- a/gtk4-session-lock/Cargo.toml
+++ b/gtk4-session-lock/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "gtk4-session-lock"
+version = "0.1.0"
+description = "Save gir-generated wrapper for gtk4-ssesion-lock"
+repository = "https://github.com/pentamassiv/gtk4-layer-shell-gir/tree/main/gtk4-session-lock"
+documentation = "https://docs.rs/gtk4-session-lock/"
+keywords = ["gtk4", "gtk4-session-lock", "wayland", "gir", "wrapper"]
+categories = ["api-bindings", "gui"]
+exclude = ["examples"]
+authors.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
+
+[features]
+
+[dependencies]
+libc.workspace = true
+glib.workspace = true
+glib-sys.workspace = true
+gdk.workspace = true
+gtk.workspace = true
+gtk4-session-lock-sys.workspace = true
+
+[dev-dependencies]
+gio.workspace = true
+
+[target.'cfg(docsrs)'.dependencies]
+gdk = { package = "gdk4", version = "0.9", features = ["gl", "v4_16"] }

--- a/gtk4-session-lock/Gir.toml
+++ b/gtk4-session-lock/Gir.toml
@@ -1,0 +1,21 @@
+[options]
+library = "Gtk4SessionLock"
+version = "1.0"
+target_path = "."
+min_cfg_version = "1.0"
+work_mode = "normal"
+girs_directories = ["../gir-files", ".."]
+generate_safety_asserts = true
+deprecate_by_min_version = true
+single_version_file = true
+
+manual = ["Gtk.Window", "Gdk.Monitor"]
+
+generate = ["Gtk4SessionLock.Instance"]
+
+[[object]]
+name = "Gtk4SessionLock.*"
+status = "ignore"
+[[object.function]]
+name = "is_supported"
+manual = true

--- a/gtk4-session-lock/examples/simple.rs
+++ b/gtk4-session-lock/examples/simple.rs
@@ -1,0 +1,81 @@
+use gio::prelude::*;
+use glib::clone;
+use gtk::prelude::*;
+use gtk4_session_lock::Instance as SessionLockInstance;
+
+fn main() {
+    if !gtk4_session_lock::is_supported() {
+        println!("Session lock not supported")
+    }
+
+    let app = gtk::Application::new(
+        Some("com.github.wmww.gtk4-layer-shell.session-lock-example"),
+        Default::default(),
+    );
+
+    app.connect_activate(activate);
+    app.run();
+}
+
+fn activate(app: &gtk::Application) {
+    let lock = SessionLockInstance::new();
+    lock.connect_locked(locked);
+    lock.connect_failed(failed);
+
+    lock.connect_unlocked(clone!(
+        #[weak]
+        app,
+        move |_| unlocked(&app)
+    ));
+
+    if !lock.lock() {
+        // Error message already shown when handling the ::failed signal
+        return;
+    }
+
+    let display = gdk::Display::default().unwrap();
+    let monitors = display.monitors();
+    for monitor in monitors.iter::<glib::Object>() {
+        let monitor = monitor.unwrap().downcast::<gdk::Monitor>().unwrap();
+        let window = gtk::ApplicationWindow::new(app);
+        lock.assign_window_to_monitor(&window, &monitor);
+
+        let bbox = gtk::Box::builder()
+            .orientation(gtk::Orientation::Vertical)
+            .halign(gtk::Align::Center)
+            .valign(gtk::Align::Center)
+            .spacing(10)
+            .build();
+
+        let label = gtk::Label::new(Some("GTK4 Session Lock Example"));
+        let button = gtk::Button::builder()
+            .label("Unlock")
+            .halign(gtk::Align::Center)
+            .valign(gtk::Align::Center)
+            .build();
+
+        let lock = lock.clone();
+        button.connect_clicked(move |_| lock.unlock());
+
+        // Not displayed, but allows testing that creating popups doesn't crash GTK
+        button.set_tooltip_text(Some("Foo Bar Baz"));
+
+        bbox.append(&label);
+        bbox.append(&button);
+        window.set_child(Some(&bbox));
+        window.present();
+    }
+}
+
+fn locked(_: &SessionLockInstance) {
+    println!("Session locked successfully");
+}
+
+fn failed(_: &SessionLockInstance) {
+    eprintln!("The session could not be locked");
+}
+
+fn unlocked(app: &gtk::Application) {
+    println!("Session unlocked");
+    app.quit();
+}

--- a/gtk4-session-lock/src/lib.rs
+++ b/gtk4-session-lock/src/lib.rs
@@ -1,0 +1,22 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(warnings)]
+
+use gtk4_session_lock_sys as ffi;
+
+macro_rules! assert_initialized_main_thread {
+    () => {
+        if !::gtk::is_initialized_main_thread() {
+            if ::gtk::is_initialized() {
+                panic!("GTK may only be used from the main thread.");
+            } else {
+                panic!("GTK has not been initialized. Call `gtk::init` first.");
+            }
+        }
+    };
+}
+
+mod auto;
+pub use auto::Instance;
+
+mod manual;
+pub use manual::is_supported;

--- a/gtk4-session-lock/src/manual.rs
+++ b/gtk4-session-lock/src/manual.rs
@@ -1,0 +1,14 @@
+use glib::translate::from_glib;
+
+use crate::ffi;
+
+/// May block for a Wayland roundtrip the first time it's called.
+///
+/// # Returns
+///
+/// [`true`] if the platform is Wayland and Wayland compositor supports the
+/// Session Lock protocol.
+#[doc(alias = "gtk_session_lock_is_supported")]
+pub fn is_supported() -> bool {
+    unsafe { from_glib(ffi::gtk_session_lock_is_supported()) }
+}


### PR DESCRIPTION
So, I've generated the files for gtk4-session-lock. I was surprised to see that it actually generates a separate gir file even though both libraries depend on the same lib file in the end (and I suspect the lib can only be imported once because it patches wayland client methods).

Since gir files can't be combined, I've had to create a whole new set of ffi and rust modules/crates here. I think it would be fine to keep these in this repository since they depend on the same library, but if you'd rather I release these myself, I'm fine with that as well.
