### PR TITLE
Don't strip the comments from the manual implementations

### DIFF
--- a/.github/actions/build_test_commit/action.yaml
+++ b/.github/actions/build_test_commit/action.yaml
@@ -56,7 +56,7 @@ runs:
           fi
           # Documentation processing
           cargo install rustdoc-stripper --force
-          rustdoc-stripper -s -n
+          rustdoc-stripper -s -n --ignore src/manual.rs
           rustdoc-stripper -g -o docs.md
           # Build and test
           cargo update

--- a/gtk4-session-lock/src/manual.rs
+++ b/gtk4-session-lock/src/manual.rs
@@ -2,6 +2,12 @@ use glib::translate::from_glib;
 
 use crate::ffi;
 
+/// May block for a Wayland roundtrip the first time it's called.
+///
+/// # Returns
+///
+/// [`true`] if the platform is Wayland and Wayland compositor supports the
+/// Session Lock protocol.
 #[doc(alias = "gtk_session_lock_is_supported")]
 pub fn is_supported() -> bool {
     unsafe { from_glib(ffi::gtk_session_lock_is_supported()) }


### PR DESCRIPTION
rustdoc-stripper removed the doc comment from the manual implementation but it's unable to add them back. We can just ignore the `manual.rs` file to not remove the comment.